### PR TITLE
WiFly/UART support

### DIFF
--- a/WebSocketClient.cpp
+++ b/WebSocketClient.cpp
@@ -49,19 +49,18 @@ PROGMEM const char *WebSocketClientStringTable[] =
 
 #ifdef WIFLY
 WebSocketClient::WebSocketClient(WiFlySerial &WiFly) : _client(WiFly) {
-
 }
 #endif
 
 
 String WebSocketClient::getStringTableItem(int index) {
-char buffer[35];
+    char buffer[35];
     strcpy_P(buffer, (char*)pgm_read_word(&(WebSocketClientStringTable[index])));
     return String(buffer);
 }
 
 
-bool WebSocketClient::connect(char hostname[], char path[], int port) {
+bool WebSocketClient::connect(const char *hostname, const char *path, int port) {
     bool result = false;
 
     if (_client.connect(hostname, port)) {
@@ -103,11 +102,11 @@ void WebSocketClient::monitor () {
 }
 
 void WebSocketClient::setDataArrivedDelegate(DataArrivedDelegate dataArrivedDelegate) {
-	  _dataArrivedDelegate = dataArrivedDelegate;
+	_dataArrivedDelegate = dataArrivedDelegate;
 }
 
 
-void WebSocketClient::sendHandshake(char hostname[], char path[]) {
+void WebSocketClient::sendHandshake(const char *hostname, const char *path) {
     String stringVar = getStringTableItem(0);
     String line1 = getStringTableItem(1);
     String line2 = getStringTableItem(2);
@@ -170,4 +169,37 @@ void WebSocketClient::send (String data) {
 	_client.print(data);
     _client.print((char)255);
 }
+
+// implementation thanks to Tom Waldock and his
+// his WiFlySerial project.
+
+// setDebugChannel
+// Conduit for debug output
+// must not be a NewSoftSerial instance as incoming interrupts conflicts with outgoing data.
+void WebSocketClient::setDebugChannel(Print* pChannel) {
+    pDebugChannel = pChannel;
+#ifdef WIFLY
+    _client.setDebugChannel(pChannel);
+#endif
+}
+void WebSocketClient::clearDebugChannel() {
+    pDebugChannel = NULL;
+#ifdef WIFLY
+    _client.clearDebugChannel();
+#endif
+}
+
+void WebSocketClient::DebugPrint(const char* pMessage) {
+    if ( pDebugChannel )
+        pDebugChannel->println(pMessage);
+}
+void WebSocketClient::DebugPrint(const int iNumber) {
+    if ( pDebugChannel )
+        pDebugChannel->println(iNumber);
+}
+void WebSocketClient::DebugPrint(const char ch) {
+    if ( pDebugChannel )
+        pDebugChannel->print(ch);
+}
+
 

--- a/WebSocketClient.cpp
+++ b/WebSocketClient.cpp
@@ -47,7 +47,7 @@ PROGMEM const char *WebSocketClientStringTable[] =
 };
 
 String WebSocketClient::getStringTableItem(int index) {
-    char buffer[35];
+char buffer[35];
     strcpy_P(buffer, (char*)pgm_read_word(&(WebSocketClientStringTable[index])));
     return String(buffer);
 }

--- a/WebSocketClient.cpp
+++ b/WebSocketClient.cpp
@@ -26,6 +26,7 @@
 #include <WString.h>
 #include <string.h>
 #include <stdlib.h>
+#include "WiFlyClient.h"
 
 prog_char stringVar[] PROGMEM = "{0}";
 prog_char clientHandshakeLine1[] PROGMEM = "GET {0} HTTP/1.1";
@@ -45,6 +46,13 @@ PROGMEM const char *WebSocketClientStringTable[] =
     clientHandshakeLine5,
     serverHandshake
 };
+
+#ifdef WIFLY
+WebSocketClient::WebSocketClient(WiFlySerial &WiFly) : _client(WiFly) {
+
+}
+#endif
+
 
 String WebSocketClient::getStringTableItem(int index) {
 char buffer[35];

--- a/WebSocketClient.cpp
+++ b/WebSocketClient.cpp
@@ -2,17 +2,17 @@
  WebsocketClient, a websocket client for Arduino
  Copyright 2011 Kevin Rohling
  http://kevinrohling.com
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in
  all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -36,7 +36,7 @@ prog_char clientHandshakeLine5[] PROGMEM = "Origin: ArduinoWebSocketClient";
 prog_char serverHandshake[] PROGMEM = "HTTP/1.1 101";
 
 PROGMEM const char *WebSocketClientStringTable[] =
-{   
+{
     stringVar,
     clientHandshakeLine1,
     clientHandshakeLine2,
@@ -52,6 +52,7 @@ String WebSocketClient::getStringTableItem(int index) {
     return String(buffer);
 }
 
+
 bool WebSocketClient::connect(char hostname[], char path[], int port) {
     bool result = false;
 
@@ -59,7 +60,7 @@ bool WebSocketClient::connect(char hostname[], char path[], int port) {
         sendHandshake(hostname, path);
         result = readHandshake();
     }
-    
+
 	return result;
 }
 
@@ -74,7 +75,7 @@ void WebSocketClient::disconnect() {
 
 void WebSocketClient::monitor () {
     char character;
-    
+
 	if (_client.available() > 0 && (character = _client.read()) == 0) {
         String data = "";
         bool endReached = false;
@@ -86,7 +87,7 @@ void WebSocketClient::monitor () {
                 data += character;
             }
         }
-        
+
         if (_dataArrivedDelegate != NULL) {
             _dataArrivedDelegate(*this, data);
         }
@@ -105,10 +106,10 @@ void WebSocketClient::sendHandshake(char hostname[], char path[]) {
     String line3 = getStringTableItem(3);
     String line4 = getStringTableItem(4);
     String line5 = getStringTableItem(5);
-    
+
     line1.replace(stringVar, path);
     line4.replace(stringVar, hostname);
-    
+
     _client.println(line1);
     _client.println(line2);
     _client.println(line3);
@@ -122,37 +123,37 @@ bool WebSocketClient::readHandshake() {
     char character;
     String handshake = "", line;
     int maxAttempts = 300, attempts = 0;
-    
-    while(_client.available() == 0 && attempts < maxAttempts) 
-    { 
-        delay(100); 
+
+    while(_client.available() == 0 && attempts < maxAttempts)
+    {
+        delay(100);
         attempts++;
     }
-    
+
     while((line = readLine()) != "") {
         handshake += line + '\n';
     }
-    
+
     String response = getStringTableItem(6);
     result = handshake.indexOf(response) != -1;
-    
+
     if(!result) {
         _client.stop();
     }
-    
+
     return result;
 }
 
 String WebSocketClient::readLine() {
     String line = "";
     char character;
-    
+
     while(_client.available() > 0 && (character = _client.read()) != '\n') {
         if (character != '\r' && character != -1) {
             line += character;
         }
     }
-    
+
     return line;
 }
 

--- a/WebSocketClient.cpp
+++ b/WebSocketClient.cpp
@@ -50,6 +50,12 @@ PROGMEM const char *WebSocketClientStringTable[] =
 #ifdef WIFLY
 WebSocketClient::WebSocketClient(WiFlySerial &WiFly) : _client(WiFly) {
 }
+
+WebSocketClient::WebSocketClient(const char *ssid, const char *password) : _client(ssid, password) {
+}
+
+WebSocketClient::WebSocketClient(int rxPin, int txPin, const char *ssid, const char *password) : _client(rxPin, txPin, ssid, password) {
+}
 #endif
 
 

--- a/WebSocketClient.h
+++ b/WebSocketClient.h
@@ -2,17 +2,17 @@
  WebsocketClient, a websocket client for Arduino
  Copyright 2011 Kevin Rohling
  http://kevinrohling.com
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in
  all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,14 +25,21 @@
 #ifndef WEBSOCKETCLIENT_H
 #define WEBSOCKETCLIENT_H_
 
+//Uncomment this to use WIFLY Client
+#define WIFLY true
+
 #include <string.h>
 #include <stdlib.h>
 #include <WString.h>
-#include <Ethernet.h>
-#include "Arduino.h"
 
-//Uncomment this to use WIFLY Client
-#define WIFLY true
+
+#ifdef WIFLY
+#include "WiFlyClient.h"
+#else
+#include <Ethernet.h>
+#endif
+
+#include "Arduino.h"
 
 class WebSocketClient {
 	public:
@@ -46,7 +53,11 @@ class WebSocketClient {
 	private:
         String getStringTableItem(int index);
         void sendHandshake(char hostname[], char path[]);
+#ifdef WIFLY
+        WiFlyClient _client;
+else
         EthernetClient _client;
+#endif
         DataArrivedDelegate _dataArrivedDelegate;
         bool readHandshake();
         String readLine();

--- a/WebSocketClient.h
+++ b/WebSocketClient.h
@@ -48,6 +48,8 @@ class WebSocketClient {
 
 #ifdef WIFLY
         WebSocketClient(WiFlySerial &WiFly);
+        WebSocketClient(const char *ssid, const char *password);
+        WebSocketClient(int rxPin, int txPin, const char *ssid, const char *password);
 #else
         WebSocketClient();
 #endif

--- a/WebSocketClient.h
+++ b/WebSocketClient.h
@@ -35,6 +35,7 @@
 
 #ifdef WIFLY
 #include "WiFlyClient.h"
+#include <WiFlySerial.h>
 #else
 #include <Ethernet.h>
 #endif
@@ -44,6 +45,12 @@
 class WebSocketClient {
 
     public:
+
+#ifdef WIFLY
+        WebSocketClient(WiFlySerial &WiFly);
+#else
+        WebSocketClient();
+#endif
 
         typedef void (*DataArrivedDelegate)(WebSocketClient client, String data);
         bool connect(char hostname[], char path[] = "/", int port = 80);
@@ -58,10 +65,10 @@ class WebSocketClient {
         String getStringTableItem(int index);
         void sendHandshake(char hostname[], char path[]);
 
-#ifdef WIFLY
-        WiFlyClient _client;
-#else
+#ifndef WIFLY
         EthernetClient _client;
+#else
+        WiFlyClient _client;
 #endif
 
         DataArrivedDelegate _dataArrivedDelegate;

--- a/WebSocketClient.h
+++ b/WebSocketClient.h
@@ -53,17 +53,29 @@ class WebSocketClient {
 #endif
 
         typedef void (*DataArrivedDelegate)(WebSocketClient client, String data);
-        bool connect(char hostname[], char path[] = "/", int port = 80);
+        bool connect(const char *hostname, const char *path = "/", int port = 80);
         bool connected();
         void disconnect();
         void monitor();
         void setDataArrivedDelegate(DataArrivedDelegate dataArrivedDelegate);
         void send(String data);
 
+        // debug utilities - use Serial : not NewSoftSerial as it will affect incoming stream.
+        // should change these to use stream <<
+        void setDebugChannel( Print* pDebug);
+        Print* getDebugChannel()  { return pDebugChannel; };
+        void clearDebugChannel();
+        void DebugPrint( const char* pMessage);
+        void DebugPrint( const int iNumber);
+        void DebugPrint( const char ch);
+
+
     private:
 
         String getStringTableItem(int index);
-        void sendHandshake(char hostname[], char path[]);
+        void sendHandshake(const char *hostname, const char *path);
+        Print* pDebugChannel;
+
 
 #ifndef WIFLY
         EthernetClient _client;

--- a/WebSocketClient.h
+++ b/WebSocketClient.h
@@ -42,22 +42,28 @@
 #include "Arduino.h"
 
 class WebSocketClient {
-	public:
-		typedef void (*DataArrivedDelegate)(WebSocketClient client, String data);
-		bool connect(char hostname[], char path[] = "/", int port = 80);
+
+    public:
+
+        typedef void (*DataArrivedDelegate)(WebSocketClient client, String data);
+        bool connect(char hostname[], char path[] = "/", int port = 80);
         bool connected();
         void disconnect();
-		void monitor();
-		void setDataArrivedDelegate(DataArrivedDelegate dataArrivedDelegate);
-		void send(String data);
-	private:
+        void monitor();
+        void setDataArrivedDelegate(DataArrivedDelegate dataArrivedDelegate);
+        void send(String data);
+
+    private:
+
         String getStringTableItem(int index);
         void sendHandshake(char hostname[], char path[]);
+
 #ifdef WIFLY
         WiFlyClient _client;
-else
+#else
         EthernetClient _client;
 #endif
+
         DataArrivedDelegate _dataArrivedDelegate;
         bool readHandshake();
         String readLine();

--- a/WiFlyClient.cpp
+++ b/WiFlyClient.cpp
@@ -1,0 +1,14 @@
+#include "Arduino.h"
+#include "WiFlyClient.h"
+#include <WiFlySerial.h>
+
+
+WiFlyClient::WiFlyClient(WiFlySerial *WiFly) {
+  _WiFly = WiFly;
+}
+
+int WiFlyClient::connect(char hostname[], char path[] = "/", int port = 80) {
+  _hostname = hostname;
+  _port     = port;
+  _path     = path;
+}

--- a/WiFlyClient.cpp
+++ b/WiFlyClient.cpp
@@ -1,44 +1,42 @@
 #include "WiFlyClient.h"
 #include <WiFlySerial.h>
 
-WiFlyClient::WiFlyClient(WiFlySerial *WiFly) {
-    _WiFly = WiFly;
+WiFlyClient::WiFlyClient(WiFlySerial &WiFly) : _WiFly(WiFly) {
+
 }
 
-bool WiFlyClient::connect(const char hostname[], int port = 80) {
-    _hostname = hostname;
-    _port     = port;
+bool WiFlyClient::connect(const char hostname[], int port) {
     return _WiFly.openConnection(hostname, port);
 }
 
-void print(const char *str) {
-    _WiFly.uart.print(str);
+void WiFlyClient::print(const char &s) {
+    _WiFly.uart.print(s);
 }
 
-void print(const String *str) {
-    _WiFly.uart.print(str);
+void WiFlyClient::print(const String &s) {
+    _WiFly.uart.print(s);
 }
 
-void println(const String *str) {
-    _WiFly.uart.println(str);
+void WiFlyClient::println(const String &s) {
+    _WiFly.uart.println(s);
 }
 
-void println() {
+void WiFlyClient::println() {
     _WiFly.uart.println("\n");
 }
 
-int read() {
+int WiFlyClient::read() {
     return _WiFly.uart.read();
 }
 
-int available() {
+int WiFlyClient::available() {
     return _WiFly.uart.available();
 }
 
-bool connected() {
+bool WiFlyClient::connected() {
     return _WiFly.isConnected();
 }
 
-void stop() {
+void WiFlyClient::stop() {
     _WiFly.closeConnection();
 }

--- a/WiFlyClient.cpp
+++ b/WiFlyClient.cpp
@@ -23,6 +23,10 @@ void println(const String *str) {
   _WiFly.uart.println(str);
 }
 
+void println() {
+  _WiFly.uart.println("\n");
+}
+
 int read() {
   return _WiFly.uart.read();
 }

--- a/WiFlyClient.cpp
+++ b/WiFlyClient.cpp
@@ -2,43 +2,43 @@
 #include <WiFlySerial.h>
 
 WiFlyClient::WiFlyClient(WiFlySerial *WiFly) {
-  _WiFly = WiFly;
+    _WiFly = WiFly;
 }
 
-bool WiFlyClient::connect(char hostname[], int port = 80) {
-  _hostname = hostname;
-  _port     = port;
-  return _WiFly.openConnection(hostname, port);
+bool WiFlyClient::connect(const char hostname[], int port = 80) {
+    _hostname = hostname;
+    _port     = port;
+    return _WiFly.openConnection(hostname, port);
 }
 
 void print(const char *str) {
-  _WiFly.uart.print(str);
+    _WiFly.uart.print(str);
 }
 
 void print(const String *str) {
-  _WiFly.uart.print(str);
+    _WiFly.uart.print(str);
 }
 
 void println(const String *str) {
-  _WiFly.uart.println(str);
+    _WiFly.uart.println(str);
 }
 
 void println() {
-  _WiFly.uart.println("\n");
+    _WiFly.uart.println("\n");
 }
 
 int read() {
-  return _WiFly.uart.read();
+    return _WiFly.uart.read();
 }
 
 int available() {
-  return _WiFly.uart.available();
+    return _WiFly.uart.available();
 }
 
 bool connected() {
-  return _WiFly.isConnected();
+    return _WiFly.isConnected();
 }
 
 void stop() {
-  _WiFly.closeConnection();
+    _WiFly.closeConnection();
 }

--- a/WiFlyClient.cpp
+++ b/WiFlyClient.cpp
@@ -1,4 +1,3 @@
-#include "Arduino.h"
 #include "WiFlyClient.h"
 #include <WiFlySerial.h>
 

--- a/WiFlyClient.cpp
+++ b/WiFlyClient.cpp
@@ -1,8 +1,32 @@
 #include "WiFlyClient.h"
 #include <WiFlySerial.h>
 
+#define ARD_DEFAULT_RX_PIN 2
+#define ARD_DEFAULT_TX_PIN 3
+
+WiFlyClient::WiFlyClient(int rxPin, int txPin, const char *ssid, const char *password) : _WiFly(rxPin, txPin) {
+    initializeWiFly(ssid, password);
+}
+
+WiFlyClient::WiFlyClient(const char *ssid, const char *password) : _WiFly(ARD_DEFAULT_RX_PIN, ARD_DEFAULT_TX_PIN) {
+    initializeWiFly(ssid, password);
+}
+
 WiFlyClient::WiFlyClient(WiFlySerial &WiFly) : _WiFly(WiFly) {
 
+}
+
+
+void WiFlyClient::initializeWiFly(const char *ssid, const char *password) {
+    _WiFly.begin();
+    if (!_WiFly.isConnected()) {
+        _WiFly.leave(); // restart my link
+        _WiFly.SendCommand("set com remote 0", "AOK");
+        _WiFly.SendCommand("set opt jointmr 5000", "AOK");
+        _WiFly.setSSID(ssid);
+        _WiFly.setPassphrase(password);
+        _WiFly.join();
+    }
 }
 
 bool WiFlyClient::connect(const char *hostname, int port) {

--- a/WiFlyClient.cpp
+++ b/WiFlyClient.cpp
@@ -5,7 +5,7 @@ WiFlyClient::WiFlyClient(WiFlySerial &WiFly) : _WiFly(WiFly) {
 
 }
 
-bool WiFlyClient::connect(const char hostname[], int port) {
+bool WiFlyClient::connect(const char *hostname, int port) {
     return _WiFly.openConnection(hostname, port);
 }
 
@@ -40,3 +40,30 @@ bool WiFlyClient::connected() {
 void WiFlyClient::stop() {
     _WiFly.closeConnection();
 }
+
+// implementation thanks to Tom Waldock and his
+// his WiFlySerial project.
+
+// setDebugChannel
+// Conduit for debug output
+// must not be a NewSoftSerial instance as incoming interrupts conflicts with outgoing data.
+void WiFlyClient::setDebugChannel(Print* pChannel) {
+    pDebugChannel = pChannel;
+}
+void WiFlyClient::clearDebugChannel() {
+    pDebugChannel = NULL;
+}
+
+void WiFlyClient::DebugPrint(const char* pMessage) {
+    if ( pDebugChannel )
+        pDebugChannel->println(pMessage);
+}
+void WiFlyClient::DebugPrint(const int iNumber) {
+    if ( pDebugChannel )
+        pDebugChannel->println(iNumber);
+}
+void WiFlyClient::DebugPrint(const char ch) {
+  if ( pDebugChannel )
+    pDebugChannel->print(ch);
+}
+

--- a/WiFlyClient.cpp
+++ b/WiFlyClient.cpp
@@ -2,13 +2,40 @@
 #include "WiFlyClient.h"
 #include <WiFlySerial.h>
 
-
 WiFlyClient::WiFlyClient(WiFlySerial *WiFly) {
   _WiFly = WiFly;
 }
 
-int WiFlyClient::connect(char hostname[], char path[] = "/", int port = 80) {
+bool WiFlyClient::connect(char hostname[], int port = 80) {
   _hostname = hostname;
   _port     = port;
-  _path     = path;
+  return _WiFly.openConnection(hostname, port);
+}
+
+void print(const char *str) {
+  _WiFly.uart.print(str);
+}
+
+void print(const String *str) {
+  _WiFly.uart.print(str);
+}
+
+void println(const String *str) {
+  _WiFly.uart.println(str);
+}
+
+int read() {
+  return _WiFly.uart.read();
+}
+
+int available() {
+  return _WiFly.uart.available();
+}
+
+bool connected() {
+  return _WiFly.isConnected();
+}
+
+void stop() {
+  _WiFly.closeConnection();
 }

--- a/WiFlyClient.h
+++ b/WiFlyClient.h
@@ -16,7 +16,7 @@ class WiFlyClient {
         // Let the user worry about authentication and pin mapping.
         WiFlyClient(WiFlySerial &WiFly);
 
-        bool connect(const char hostname[], int port = 80);
+        bool connect(const char *hostname, int port = 80);
 
         void print(const char &s);
         void print(const String &s);
@@ -30,9 +30,20 @@ class WiFlyClient {
         bool connected();
         void stop();
 
+        // debug utilities - use Serial : not NewSoftSerial as it will affect incoming stream.
+        // should change these to use stream <<
+        void setDebugChannel( Print* pDebug);
+        Print* getDebugChannel()  { return pDebugChannel; };
+        void clearDebugChannel();
+        void DebugPrint( const char* pMessage);
+        void DebugPrint( const int iNumber);
+        void DebugPrint( const char ch);
+
     private:
 
         WiFlySerial _WiFly;
+        Print* pDebugChannel;
+
 
 };
 

--- a/WiFlyClient.h
+++ b/WiFlyClient.h
@@ -1,5 +1,5 @@
 #ifndef WIFLYCLIENT_H
-#define WIFLYCLIENT_H
+#define WIFLYCLIENT_H_
 
 #include "Arduino.h"
 
@@ -9,32 +9,32 @@
 
 class WiFlyClient {
 
-public:
+    public:
 
-  // constructor expects an initialized, and fully
-  // connected instance of the WiFly driver.
-  // Let the user worry about authentication and pin mapping.
-  WiFlyClient(WiFlySerial *WiFly);
+        // constructor expects an initialized, and fully
+        // connected instance of the WiFly driver.
+        // Let the user worry about authentication and pin mapping.
+        WiFlyClient(WiFlySerial *WiFly);
 
-  bool connect(char hostname[], int port = 80);
+        bool connect(const char hostname[], int port = 80);
 
-  void print(const char *str);
-  void print(const String *str);
+        void print(const char *str);
+        void print(const String *str);
 
-  void println(const String *str);
-  void println();
+        void println(const String *str);
+        void println();
 
-  int read();
-  int available();
+        int read();
+        int available();
 
-  bool connected();
-  void stop();
+        bool connected();
+        void stop();
 
-private:
+    private:
 
-  WiFlySerial _WiFly;
-  int _port;
-  char _hostname[];
+        WiFlySerial _WiFly;
+        int _port;
+        char _hostname[];
 
 };
 

--- a/WiFlyClient.h
+++ b/WiFlyClient.h
@@ -16,7 +16,7 @@ public:
   // Let the user worry about authentication and pin mapping.
   WiFlyClient(WiFlySerial *WiFly);
 
-  bool connect(char hostname[], char path[] = "/", int port = 80);
+  bool connect(char hostname[], int port = 80);
 
   void print(const char *str);
   void print(const String *str);

--- a/WiFlyClient.h
+++ b/WiFlyClient.h
@@ -1,0 +1,44 @@
+#ifndef WIFLYCLIENT_H
+#define WIFLYCLIENT_H
+
+#include "Arduino.h"
+
+#include <WiFlySerial.h>
+#include <SoftwareSerial.h>
+#include <Streaming.h>
+
+class WiFlyClient {
+
+public:
+
+  // constructor expects an initialized, and fully
+  // connected instance of the WiFly driver.
+  // Let the user worry about authentication and pin mapping.
+  WiFlyClient(WiFlySerial *WiFly);
+
+  int connect(char hostname[], char path[] = "/", int port = 80);
+
+  void print(const char *str);
+  void print(const String *str);
+
+  void println(const String *str);
+
+  int read();
+  int available();
+
+  bool connected();
+  void stop();
+
+  operator bool();
+
+private:
+
+  WiFlySerial _WiFly;
+
+  int _port;
+  char _hostname[];
+  char _path[];
+
+};
+
+#endif

--- a/WiFlyClient.h
+++ b/WiFlyClient.h
@@ -22,6 +22,7 @@ public:
   void print(const String *str);
 
   void println(const String *str);
+  void println();
 
   int read();
   int available();

--- a/WiFlyClient.h
+++ b/WiFlyClient.h
@@ -15,6 +15,10 @@ class WiFlyClient {
         // connected instance of the WiFly driver.
         // Let the user worry about authentication and pin mapping.
         WiFlyClient(WiFlySerial &WiFly);
+    
+        WiFlyClient(const char *ssid, const char *password);
+    
+        WiFlyClient(int rxPin, int txPin, const char *ssid, const char *password);
 
         bool connect(const char *hostname, int port = 80);
 
@@ -43,7 +47,7 @@ class WiFlyClient {
 
         WiFlySerial _WiFly;
         Print* pDebugChannel;
-
+        void initializeWiFly(const char *ssid, const char *password);
 
 };
 

--- a/WiFlyClient.h
+++ b/WiFlyClient.h
@@ -1,5 +1,5 @@
 #ifndef WIFLYCLIENT_H
-#define WIFLYCLIENT_H_
+#define WIFLYCLIENT_H
 
 #include "Arduino.h"
 
@@ -14,14 +14,14 @@ class WiFlyClient {
         // constructor expects an initialized, and fully
         // connected instance of the WiFly driver.
         // Let the user worry about authentication and pin mapping.
-        WiFlyClient(WiFlySerial *WiFly);
+        WiFlyClient(WiFlySerial &WiFly);
 
         bool connect(const char hostname[], int port = 80);
 
-        void print(const char *str);
-        void print(const String *str);
+        void print(const char &s);
+        void print(const String &s);
 
-        void println(const String *str);
+        void println(const String &s);
         void println();
 
         int read();
@@ -33,8 +33,6 @@ class WiFlyClient {
     private:
 
         WiFlySerial _WiFly;
-        int _port;
-        char _hostname[];
 
 };
 

--- a/WiFlyClient.h
+++ b/WiFlyClient.h
@@ -16,7 +16,7 @@ public:
   // Let the user worry about authentication and pin mapping.
   WiFlyClient(WiFlySerial *WiFly);
 
-  int connect(char hostname[], char path[] = "/", int port = 80);
+  bool connect(char hostname[], char path[] = "/", int port = 80);
 
   void print(const char *str);
   void print(const String *str);
@@ -29,15 +29,11 @@ public:
   bool connected();
   void stop();
 
-  operator bool();
-
 private:
 
   WiFlySerial _WiFly;
-
   int _port;
   char _hostname[];
-  char _path[];
 
 };
 

--- a/examples/EchoExample/WiFly_EchoExample.ino
+++ b/examples/EchoExample/WiFly_EchoExample.ino
@@ -1,0 +1,24 @@
+#include "Arduino.h"
+#include <WebSocketClient.h>
+#include <WiFlySerial.h>
+#include <SoftwareSerial.h>
+#include <Streaming.h>
+
+byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };
+char server[] = "echo.websocket.org";
+WebSocketClient client("ssid", "password");
+
+void setup() {
+  Serial.begin(9600);
+  client.connect(server);
+  client.setDataArrivedDelegate(dataArrived);
+  client.send("Hello World!");
+}
+
+void loop() {
+  client.monitor();
+}
+
+void dataArrived(WebSocketClient client, String data) {
+  Serial.println("Data Arrived: " + data);
+}

--- a/examples/EchoExample/WiFly_EchoExample/WiFly_EchoExample.ino
+++ b/examples/EchoExample/WiFly_EchoExample/WiFly_EchoExample.ino
@@ -6,13 +6,15 @@
 
 byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };
 char server[] = "echo.websocket.org";
-WebSocketClient client("ssid", "password");
+WebSocketClient client(2, 3, "2WIRE598", "8888986907");
 
 void setup() {
   Serial.begin(9600);
+  client.setDebugChannel( (Print*) &Serial);
   client.connect(server);
   client.setDataArrivedDelegate(dataArrived);
   client.send("Hello World!");
+  Serial.println("here");
 }
 
 void loop() {


### PR DESCRIPTION
I thought we could make this official, so I started a pull request.

So, the reliance on the WiFlySerial module (here: https://github.com/perezd/arduino-wifly-serial) makes our WiFlyClient shim _very_ small.

Outstanding concerns:
1. how do we get an instance of WiFlySerial into the ArduinoWebSocketClient? My WiFlyClient class expects an instance as part of its constructor, not sure what the best way is to accomplish this just yet. That bit of integration, I could use help with.
2. does it work? :) I'm not super sharp with C++ so, I'd appreciate a thorough code review.

NOTE: lets not pull this into master yet, until we've got it working, just wanted this here for discussion purposes.
