### PR TITLE
Fixes for 32 bit boards

### DIFF
--- a/WebSocketClient.cpp
+++ b/WebSocketClient.cpp
@@ -48,7 +48,7 @@ PROGMEM const char *WebSocketClientStringTable[] =
 
 String WebSocketClient::getStringTableItem(int index) {
     char buffer[35];
-    strcpy_P(buffer, (char*)pgm_read_word(&(WebSocketClientStringTable[index])));
+    strcpy_P(buffer, (char*)pgm_read_ptr(&(WebSocketClientStringTable[index])));
     return String(buffer);
 }
 
@@ -73,7 +73,7 @@ void WebSocketClient::disconnect() {
 }
 
 void WebSocketClient::monitor () {
-    char character;
+    int character;
     
 	if (_client.available() > 0 && (character = _client.read()) == 0) {
         String data = "";
@@ -83,7 +83,7 @@ void WebSocketClient::monitor () {
             endReached = character == -1;
 
             if (!endReached) {
-                data += character;
+                data += (char)character;
             }
         }
         

--- a/examples/EchoExample/EchoExample.ino
+++ b/examples/EchoExample/EchoExample.ino
@@ -20,5 +20,5 @@ void loop() {
 }
 
 void dataArrived(WebSocketClient client, String data) {
-  Serial.println("Data Arrived: " + data);
+  Serial.println(String("Data Arrived: ") + data);
 }


### PR DESCRIPTION
These simple changes allow for compatibility with most 32 bit boards.

In the string table, pointers need to be read with pgm_read_ptr(), since pgm_read_word() is fixed at 16 bits.

In monitor(), on systems where char is unsigned the "endReached" condition can never be true.  The simple solution is to use "int" which matches the return type of _client.read() and convert to char as needed.

The example also needs to use String() to properly print the result.

I know this is a very old library that's probably not maintained anymore, but hopefully these simple changes will help anyone trying to use modern 32 bit boards.